### PR TITLE
add support for first variant price if root price not available, add …

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -81,7 +81,7 @@ var rudderTracking = (function () {
       rs$('form[action="/cart/add"] [type="submit"]').length === 1
         ? rs$('form[action="/cart/add"] [type="submit"]')
         : "";
-        
+
     identifyUser()
   
     trackPageEvent();
@@ -92,10 +92,10 @@ var rudderTracking = (function () {
   function identifyUser() {
     if(userId && cookie_action({ action: "get", name: "rudder_user_id" }) !== "captured") {
       
-      if (heapCookieObject) {
+      if (heapCookieObject && cookie_action({ action: "get", name: "rudder_heap_identities" }) !== "captured") {
         rudderanalytics.identify(userId, {
-          heapUseriD: heapCookieObject.userId,
-          session: heapCookieObject.sessionId
+          heapUserID: heapCookieObject.userId,
+          heapSessionId: heapCookieObject.sessionId
         });
         cookie_action({
           action: "set",
@@ -115,8 +115,8 @@ var rudderTracking = (function () {
     if(heapCookieObject && cookie_action({ action: "get", name: "rudder_heap_identities" }) !== "captured") {
       
       rudderanalytics.identify(rudderanalytics.getUserId(), {
-        heapUseriD: heapCookieObject.userId,
-        session: heapCookieObject.sessionId
+        heapUserID: heapCookieObject.userId,
+        heapSessionId: heapCookieObject.sessionId
       });
     
       cookie_action({

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -62,23 +62,16 @@ var rudderTracking = (function () {
     { dest: "url", src: "url" },
   ];
 
-  function getCookie(cookieName) {
-    let cookie = {};
-    document.cookie.split(';').forEach(function(el) {
-      let [key,value] = el.split('=');
-      cookie[key.trim()] = value;
-    })
-    return cookie[cookieName];
-  }
 
   function init() {
     pageCurrency = Shopify.currency.active;
     userId = ShopifyAnalytics.meta.page.customerId || __st.cid;
 
     // fetching heap Cookie object
-    heapCookieStringifiedObject = getCookie("_hp2_id.1200528076");
-    if (heapCookieStringifiedObject) {
-      heapCookieObject = JSON.parse(decodeURIComponent(heapCookieStringifiedObject))
+    heapCookieObject = cookie_action({ action: "get", name: "_hp2_id.1200528076"});
+    
+    if (heapCookieObject) {
+      heapCookieObject = JSON.parse(decodeURIComponent(heapCookieObject));
     } else {
       console.log("No heap cookie found.")
     }
@@ -95,20 +88,15 @@ var rudderTracking = (function () {
         rudderanalytics.identify(String(userId), {
           heapUserId: heapCookieObject.userId,
           heapSessionId: heapCookieObject.sessionId
-        });
-        cookie_action({
-          action: "set",
-          name: "rudder_user_id",
-          value: "captured",
-        });
+        });     
       } else {
         rudderanalytics.identify(String(userId));
-        cookie_action({
-          action: "set",
-          name: "rudder_user_id",
-          value: "captured",
-      });
       }
+      cookie_action({
+        action: "set",
+        name: "rudder_user_id",
+        value: "captured",
+      });
     }
     trackPageEvent();
     trackNamedPageView();

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -68,6 +68,7 @@ var rudderTracking = (function () {
     userId = ShopifyAnalytics.meta.page.customerId || __st.cid;
 
     // fetching heap Cookie object
+    // TODO: for adding dynamic support from source config
     heapCookieObject = cookie_action({ action: "get", name: "_hp2_id.1200528076"});
     
     if (heapCookieObject) {
@@ -80,28 +81,50 @@ var rudderTracking = (function () {
       rs$('form[action="/cart/add"] [type="submit"]').length === 1
         ? rs$('form[action="/cart/add"] [type="submit"]')
         : "";
-    if (
-      userId &&
-      cookie_action({ action: "get", name: "rudder_user_id" }) !== "captured"
-    ) {
-      if (heapCookieObject) {
-        rudderanalytics.identify(String(userId), {
-          heapUserId: heapCookieObject.userId,
-          heapSessionId: heapCookieObject.sessionId
-        });     
-      } else {
-        rudderanalytics.identify(String(userId));
-      }
-      cookie_action({
-        action: "set",
-        name: "rudder_user_id",
-        value: "captured",
-      });
-    }
+        
+    identifyUser()
+  
     trackPageEvent();
     trackNamedPageView();
 
     rs$("button[data-search-form-submit]").on("click", trackProductSearch);
+  }
+  function identifyUser() {
+    if(userId && cookie_action({ action: "get", name: "rudder_user_id" }) !== "captured") {
+      
+      if (heapCookieObject) {
+        rudderanalytics.identify(userId, {
+          heapUseriD: heapCookieObject.userId,
+          session: heapCookieObject.sessionId
+        });
+        cookie_action({
+          action: "set",
+          name: "rudder_heap_identities",
+          value: "captured"
+        });
+      } else {
+        rudderanalytics.identify(userId);
+      }
+      cookie_action({
+        action: "set",
+        name: "rudder_user_id",
+        value: "captured"
+      });
+    }
+  
+    if(heapCookieObject && cookie_action({ action: "get", name: "rudder_heap_identities" }) !== "captured") {
+      
+      rudderanalytics.identify(rudderanalytics.getUserId(), {
+        heapUseriD: heapCookieObject.userId,
+        session: heapCookieObject.sessionId
+      });
+    
+      cookie_action({
+        action: "set",
+        name: "rudder_heap_identities",
+        value: "captured"
+      });
+    }
   }
 
   // TODO: add support for product search


### PR DESCRIPTION
…support for heap

## Description of the change

- >  Shopify usually sends a `price` property for product and related pages from its end. But in some cases, this price is missing. In this PR, we are adding a fix for such cases, where-in for products having one or multiple variants, the price's value is taken from the price of the first product variant.

- > We have also added support for sending some custom traits from loaded heap cookie via traits in identify call.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
