### PR TITLE
fix: sku value to be non amalgamated, depends on variant

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -486,10 +486,12 @@ var rudderTracking = (function () {
    */
   function getVariantSku(payload) {
     const variantId = findVariantIdInURL();
-    const variant = { payload }
-    for (let i = 0; i < variant.length; i++) {
-      if (variant[i][`id`] === variantId && variantId) {
-        return variant[i][`sku`];
+    const variant = payload.variant;
+    if (variantId) {
+      for (let i = 0; i < variant.length; i++) {
+        if (String(variant[i][`id`]) === variantId) {
+          return variant[i][`sku`];
+        }
       }
     }
     return undefined;
@@ -542,7 +544,7 @@ var rudderTracking = (function () {
           data.products.forEach((product) => {
             const p = propertyMapping(product, productMapping);
             p.currency = pageCurrency;
-            p.sku = getVariantSku(p) || p.variant[0].sku || p.product_id;
+            p.sku = p.variant[0].sku || p.product_id;
             p.price = p.variant[0].price;
             payload.products.push(p);
           });

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -481,7 +481,7 @@ var rudderTracking = (function () {
 
   /**
    * Returns the sku value for the variant matching the id in url 
-   * @param {*} payload 
+   * @param {*} payload product payload generated using product mapping
    * @returns {string} matching variant's sku or undefined
    */
   function getVariantSku(payload) {
@@ -489,8 +489,8 @@ var rudderTracking = (function () {
     const variant = payload.variant;
     if (variantId) {
       for (let i = 0; i < variant.length; i++) {
-        if (String(variant[i][`id`]) === variantId) {
-          return variant[i][`sku`];
+        if (String(variant[i].id) === variantId) {
+          return variant[i].sku;
         }
       }
     }

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -516,7 +516,6 @@ var rudderTracking = (function () {
             p.currency = pageCurrency;
             p.sku = p.variant
               .map((item) => item.sku)
-              .reduce((prev, next) => prev + next);
             p.price = p.variant[0].price;
             payload.products.push(p);
           });
@@ -539,7 +538,6 @@ var rudderTracking = (function () {
         payload.currency = pageCurrency;
         payload.sku = payload.variant
           .map((item) => item.sku)
-          .reduce((prev, next) => prev + next);
         // we set root-level price property to be equal to first variant's price, if it is not available
         if (payload.variant && !payload.price) {
           payload.price = payload.variant[0].price;

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -467,6 +467,34 @@ var rudderTracking = (function () {
       });
   }
 
+  /**
+   * Checks whether the url for the product contains the variant id
+   * @returns {string} variant id or null
+   */
+  function findVariantIdInURL() {
+    const matches = window.location.href.match(/\d{8,20}/);
+    if(matches) {
+      return matches[0]
+    }
+    return null;
+  };
+
+  /**
+   * Returns the sku value for the variant matching the id in url 
+   * @param {*} payload 
+   * @returns {string} matching variant's sku or undefined
+   */
+  function getVariantSku(payload) {
+    const variantId = findVariantIdInURL();
+    const variant = { payload }
+    for (let i = 0; i < variant.length; i++) {
+      if (variant[i][`id`] === variantId && variantId) {
+        return variant[i][`sku`];
+      }
+    }
+    return undefined;
+  }
+
   // mapping seems fine
   function handleProductClicked() {
     const url = `${this.href}.json`;
@@ -514,8 +542,7 @@ var rudderTracking = (function () {
           data.products.forEach((product) => {
             const p = propertyMapping(product, productMapping);
             p.currency = pageCurrency;
-            p.sku = p.variant
-              .map((item) => item.sku)
+            p.sku = getVariantSku(p) || p.variant[0].sku || p.product_id;
             p.price = p.variant[0].price;
             payload.products.push(p);
           });
@@ -536,8 +563,7 @@ var rudderTracking = (function () {
       .done(function (data) {
         const payload = propertyMapping(data.product, productMapping);
         payload.currency = pageCurrency;
-        payload.sku = payload.variant
-          .map((item) => item.sku)
+        payload.sku = getVariantSku(payload) || payload.variant[0].sku || payload.product_id;
         // we set root-level price property to be equal to first variant's price, if it is not available
         if (payload.variant && !payload.price) {
           payload.price = payload.variant[0].price;


### PR DESCRIPTION
## Description of the change

> For products with variants, the `sku` value contains all variant SKU’s amalgamated together). We are now instead keeping `sku` to be the `sku` value for the specific product variant selected (based on the url), or the sku from first variant(if the variant id is missing). `sku` will now also have a fallback value to `product_id`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
