### PR TITLE
fix: make deviceModeInit variable as a scope variable

### DIFF
--- a/router.js
+++ b/router.js
@@ -10,12 +10,10 @@ const configUrl =
 const jsSdkCdnUrl =
   process.env.JS_SDK_CDN ||
   "https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js";
-let deviceModeInit = fs.readFileSync("./deviceModeInit.js", {
-  encoding: "utf-8",
-});
 
 router.get("/load", async (ctx) => {
   // only takes in writeKey and DataPlane Url
+
   let rudderJsCode;
   try {
     const resp = await axios.get(jsSdkCdnUrl);
@@ -27,6 +25,9 @@ router.get("/load", async (ctx) => {
   }
 
   let d = fs.readFileSync("./loadingCode.js", {
+    encoding: "utf-8",
+  });
+  let deviceModeInit = fs.readFileSync("./deviceModeInit.js", {
     encoding: "utf-8",
   });
 


### PR DESCRIPTION
## Description of the change

We are using a global variable that is making issues in adding stats. Making that as a scope variable to fix this.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
