### PR TITLE
feat: send whole cart payload for rudderIdentifier event

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -186,6 +186,7 @@ var rudderTracking = (function () {
     const data = {
       event: "rudderIdentifier",
       anonymousId: rudderanalytics.getAnonymousId(),
+      cartToken: cart.token,
       cart: cart,
     };
     rs$

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -186,7 +186,7 @@ var rudderTracking = (function () {
     const data = {
       event: "rudderIdentifier",
       anonymousId: rudderanalytics.getAnonymousId(),
-      cartToken: cart.token,
+      cart: cart,
     };
     rs$
       .ajax({


### PR DESCRIPTION
## Description of the change

> For `rudderIdentifier` payload we will be sending the whole cart payload instead of only `cart.token`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
