### PR TITLE
fix: stringify product_id before using in sku

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -545,7 +545,7 @@ var rudderTracking = (function () {
           data.products.forEach((product) => {
             const p = propertyMapping(product, productMapping);
             p.currency = pageCurrency;
-            p.sku = p.variant[0].sku || p.product_id;
+            p.sku = p.variant[0].sku || String(p.product_id);
             p.price = p.variant[0].price;
             payload.products.push(p);
           });
@@ -566,7 +566,7 @@ var rudderTracking = (function () {
       .done(function (data) {
         const payload = propertyMapping(data.product, productMapping);
         payload.currency = pageCurrency;
-        payload.sku = getVariantSku(payload) || payload.variant[0].sku || payload.product_id;
+        payload.sku = getVariantSku(payload) || payload.variant[0].sku || String(payload.product_id);
         // we set root-level price property to be equal to first variant's price, if it is not available
         if (payload.variant && !payload.price) {
           payload.price = payload.variant[0].price;

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -545,7 +545,7 @@ var rudderTracking = (function () {
           data.products.forEach((product) => {
             const p = propertyMapping(product, productMapping);
             p.currency = pageCurrency;
-            p.sku = p.variant[0].sku || String(p.product_id);
+            p.sku = String(p.variant[0].sku || p.product_id);
             p.price = p.variant[0].price;
             payload.products.push(p);
           });
@@ -566,7 +566,7 @@ var rudderTracking = (function () {
       .done(function (data) {
         const payload = propertyMapping(data.product, productMapping);
         payload.currency = pageCurrency;
-        payload.sku = getVariantSku(payload) || payload.variant[0].sku || String(payload.product_id);
+        payload.sku = String(getVariantSku(payload) || payload.variant[0].sku || payload.product_id);
         // we set root-level price property to be equal to first variant's price, if it is not available
         if (payload.variant && !payload.price) {
           payload.price = payload.variant[0].price;


### PR DESCRIPTION
## Description of the change

> We had allowed `product_id` as an alternative to `sku`, in case `sku` is not present. It needed to be stringfied.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
