### PR TITLE
fix: replace replaceAll() with regex

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -111,7 +111,9 @@ var rudderTracking = (function () {
     }
 
     htmlSelector.buttonAddToCart =
-      rs$('form[action="/cart/add"] [type="submit"]');
+      rs$('form[action="/cart/add"] [type="submit"]').length === 1
+        ? rs$('form[action="/cart/add"] [type="submit"]')
+        : "";
     fetchCart()
       .then((cart) => {
         const needToUpdateCart = checkCartNeedsToBeUpdated(cart);
@@ -747,9 +749,9 @@ var rudderTracking = (function () {
   );
   document.head.appendChild(script);
   // rs$ = $.noConflict(true);
+  // init();
+  script.addEventListener("load", function () {
+    rs$ = $.noConflict(true);
   init();
-  // script.addEventListener("load", function () {
-  //   rs$ = $.noConflict(true);
-  //   init();
-  // });
+  });
 })();

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -111,9 +111,7 @@ var rudderTracking = (function () {
     }
 
     htmlSelector.buttonAddToCart =
-      rs$('form[action="/cart/add"] [type="submit"]').length === 1
-        ? rs$('form[action="/cart/add"] [type="submit"]')
-        : "";
+      rs$('form[action="/cart/add"] [type="submit"]');
     fetchCart()
       .then((cart) => {
         const needToUpdateCart = checkCartNeedsToBeUpdated(cart);
@@ -238,7 +236,7 @@ var rudderTracking = (function () {
 
   function sendIdentifierToRudderWebhook(cart) {
     const webhookUrl =
-      "https://dataplaneUrl/v1/webhook?writeKey=writeKey_placeHolder";
+      "https://dataplaneUrl_placeHolder/v1/webhook?writeKey=writeKey_placeHolder";
     const data = {
       event: "rudderIdentifier",
       anonymousId: rudderanalytics.getAnonymousId(),
@@ -749,9 +747,9 @@ var rudderTracking = (function () {
   );
   document.head.appendChild(script);
   // rs$ = $.noConflict(true);
-  // init();
-  script.addEventListener("load", function () {
-    rs$ = $.noConflict(true);
-    init();
-  });
+  init();
+  // script.addEventListener("load", function () {
+  //   rs$ = $.noConflict(true);
+  //   init();
+  // });
 })();

--- a/router.js
+++ b/router.js
@@ -45,9 +45,9 @@ router.get("/load", async (ctx) => {
   d = d.replace("dataPlaneUrl", dataPlaneUrl);
   d = d.replace("configBackendUrl", configUrl);
 
-  deviceModeInit = deviceModeInit.replace(/dataplaneUrl/g, dataPlaneUrl);
+  deviceModeInit = deviceModeInit.replace(/dataplaneUrl_placeHolder/g, dataPlaneUrl);
   deviceModeInit = deviceModeInit.replace(/writeKey_placeHolder/g, writeKey);
-  deviceModeInit = deviceModeInit.replace(/writeKey_placeHolder/g, configUrl);
+  deviceModeInit = deviceModeInit.replace(/configUrl_placeholder/g, configUrl);
 
   // console.log("d", d);
   ctx.response.body = d + rudderJsCode + deviceModeInit;

--- a/router.js
+++ b/router.js
@@ -45,9 +45,9 @@ router.get("/load", async (ctx) => {
   d = d.replace("dataPlaneUrl", dataPlaneUrl);
   d = d.replace("configBackendUrl", configUrl);
 
-  deviceModeInit = deviceModeInit.replaceAll("dataplaneUrl", dataPlaneUrl);
-  deviceModeInit = deviceModeInit.replaceAll("writeKey_placeHolder", writeKey);
-  deviceModeInit = deviceModeInit.replaceAll("configUrl_placeholder", configUrl);
+  deviceModeInit = deviceModeInit.replace(/dataplaneUrl/g, dataPlaneUrl);
+  deviceModeInit = deviceModeInit.replace(/writeKey_placeHolder/g, writeKey);
+  deviceModeInit = deviceModeInit.replace(/writeKey_placeHolder/g, configUrl);
 
   // console.log("d", d);
   ctx.response.body = d + rudderJsCode + deviceModeInit;


### PR DESCRIPTION
## Description of the change

> Replacing the use of replaceAll() in #32 with regex expression as replaceAll() is not supported in currently used node v14. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
