### PR TITLE
fix: fire product added event for multiple add to cart buttons

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -111,9 +111,7 @@ var rudderTracking = (function () {
     }
 
     htmlSelector.buttonAddToCart =
-      rs$('form[action="/cart/add"] [type="submit"]').length === 1
-        ? rs$('form[action="/cart/add"] [type="submit"]')
-        : "";
+      rs$('form[action="/cart/add"] [type="submit"]')
     fetchCart()
       .then((cart) => {
         const needToUpdateCart = checkCartNeedsToBeUpdated(cart);


### PR DESCRIPTION
## Description of the change

> When there were more than add to cart button we were not tracking any button but now we will be tracking every add to cart button giving us the capability to fire events on any button click. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
