### PR TITLE
fix: reset analytics when user logs out to reset cache 

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -96,7 +96,7 @@ var rudderTracking = (function () {
    when user logs in for first time we make the identify call and set `rudder_user_id`
    cookie as `captured` and hence we are leveraging the same 
   */
-  const checkIfuserLoggedOut = userId => {
+  const checkIfUserLoggedOut = userId => {
     if (!userId) {
       const wasUserIdentifiedPreviously = cookie_action({ action: "get", name: "rudder_user_id" }) === "captured";
       if (wasUserIdentifiedPreviously) {
@@ -115,7 +115,7 @@ var rudderTracking = (function () {
   function init() {
     pageCurrency = Shopify.currency.active;
     userId = ShopifyAnalytics.meta.page.customerId || __st.cid;
-    const userLoggedOut = checkIfuserLoggedOut(userId);
+    const userLoggedOut = checkIfUserLoggedOut(userId);
 
     // fetching heap Cookie object
     // TODO: for adding dynamic support from source config

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -91,24 +91,32 @@ var rudderTracking = (function () {
         })
     });
   }
-  function init() {
-    pageCurrency = Shopify.currency.active;
-    userId = ShopifyAnalytics.meta.page.customerId || __st.cid;
-    let anonymousIdChanged = false;
-    // checking if user logged out after logging in once
+
+  /* checking if user logged out after logging in once
+   when user logs in for first time we make the identify call and set `rudder_user_id`
+   cookie as `captured` and hence we are leveraging the same 
+  */
+  const checkIfuserLoggedOut = userId => {
     if (!userId) {
       const wasUserIdentifiedPreviously = cookie_action({ action: "get", name: "rudder_user_id" }) === "captured";
-      // when user logs in for first time we make the identify call and set this cookie as captured and hence we are leveraging the same 
       if (wasUserIdentifiedPreviously) {
-        rudderanalytics.reset(true); // reseting since it is a new user session now after logout operation is done
+        rudderanalytics.reset(true);
         anonymousIdChanged = true;
         cookie_action({
           action: "set",
           name: "rudder_user_id",
           value: "Not Captured"
         });
+        return true;
       }
     }
+    return false;
+  }
+  function init() {
+    pageCurrency = Shopify.currency.active;
+    userId = ShopifyAnalytics.meta.page.customerId || __st.cid;
+    const userLoggedOut = checkIfuserLoggedOut(userId);
+
     // fetching heap Cookie object
     // TODO: for adding dynamic support from source config
     heapCookieObject = cookie_action({
@@ -127,7 +135,7 @@ var rudderTracking = (function () {
     fetchCart()
       .then((cart) => {
         const needToUpdateCart = checkCartNeedsToBeUpdated(cart);
-        if (anonymousIdChanged || needToUpdateCart) {
+        if (userLoggedOut || needToUpdateCart) {
           updateCartAttribute().then((cart) => {
             sendIdentifierToRudderWebhook(cart);
           });

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -93,7 +93,9 @@ var rudderTracking = (function () {
     });
   }
   function init() {
-    const config = { subtree: true, childList: true };
+    window.addEventListener('locationchange', function () {
+      console.log('onlocationchange event occurred!');
+    })
     pageCurrency = Shopify.currency.active;
     userId = ShopifyAnalytics.meta.page.customerId || __st.cid;
     // fetching heap Cookie object
@@ -260,6 +262,7 @@ var rudderTracking = (function () {
     trackPageEvent();
     trackNamedPageView();
 
+    // TODO: Correct this listner
     rs$("button[data-search-form-submit]").on("click", trackProductSearch);
   }
   function checkAndSendRudderIdentifier() {
@@ -425,7 +428,9 @@ var rudderTracking = (function () {
       case "/products":
       case "/collections/":
       case "/products/":
+
         trackProductPages(mappedPageName);
+        //TODO: check for mappedPageName and give an example for it
         break;
 
       case "/cart":
@@ -495,6 +500,12 @@ var rudderTracking = (function () {
       }
       // If the url is = /products/{productId}
       else if (pagePathArr[pagePathArr.length - 2] == "products") {
+        var replaceState = history.replaceState;
+        history.replaceState = function () {
+          replaceState.apply(history, arguments);
+          // check if variant is changed or for a variantId if product viewed event is already sent (cookies)
+        };
+        const variantId = getCurrentVariantId();
         productPage(mappedPageName);
       }
     }
@@ -755,11 +766,11 @@ var rudderTracking = (function () {
       });
   }
 
-  function productPage(event, url = null) {
+  function productPage(event, url = null, variantId) {
+
     if (url === null) {
       url = getUrl();
     }
-    const variantId = getCurrentVariantId();
     _getJsonData(url)
       .done(function (data) {
         const payload = propertyMapping(data.product, productMapping, variantId);

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -185,10 +185,10 @@ var rudderTracking = (function () {
               );
               rudderstackProduct.currency = pageCurrency;
               rudderstackProduct.sku = String(
-                rudderstackProduct.variant[0].sku ||
+                rudderstackProduct.variant?.sku ||
                   rudderstackProduct.product_id
               );
-              rudderstackProduct.price = rudderstackProduct.variant[0].price;
+              rudderstackProduct.price = rudderstackProduct.variant?.price;
               products.push(rudderstackProduct);
               productsToSend.push(rudderstackProduct);
             })
@@ -408,7 +408,12 @@ var rudderTracking = (function () {
         }
       } else {
         if (payload[j.src]) {
-          destinationPayload[j.dest] = payload[j.src];
+          if (j.src === "variants" && Array.isArray(payload[j.src])) {
+            destinationPayload[j.dest] = payload[j.src][0];
+          } else {
+            destinationPayload[j.dest] = payload[j.src];
+          }
+          // destinationPayload[j.dest] = payload[j.src];
           delete payload[j.src];
         }
       }

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -2,7 +2,6 @@ var rudderTracking = (function () {
   const pages = {
     "/products/": "Product Viewed",
     "/cart": "Cart Viewed",
-    "/collections/": "",
     "/account/register": "Registration Viewed",
     "/account/login": "Login Viewed",
   };
@@ -86,7 +85,7 @@ var rudderTracking = (function () {
             }
           },
           error: function (xhr, status, error) {
-            console.log("Couldn't fetch Source Config due error: " + xhr.responseJSON.message);
+            console.error("Couldn't fetch Source Config due error: " + xhr.responseJSON.message);
             resolve(true);
           }
         })
@@ -95,6 +94,21 @@ var rudderTracking = (function () {
   function init() {
     pageCurrency = Shopify.currency.active;
     userId = ShopifyAnalytics.meta.page.customerId || __st.cid;
+    let anonymousIdChanged = false;
+    // checking if user logged out after logging in once
+    if (!userId) {
+      const wasUserIdentifiedPreviously = cookie_action({ action: "get", name: "rudder_user_id" }) === "captured";
+      // when user logs in for first time we make the identify call and set this cookie as captured and hence we are leveraging the same 
+      if (wasUserIdentifiedPreviously) {
+        rudderanalytics.reset(true); // reseting since it is a new user session now after logout operation is done
+        anonymousIdChanged = true;
+        cookie_action({
+          action: "set",
+          name: "rudder_user_id",
+          value: "Not Captured"
+        });
+      }
+    }
     // fetching heap Cookie object
     // TODO: for adding dynamic support from source config
     heapCookieObject = cookie_action({
@@ -105,7 +119,7 @@ var rudderTracking = (function () {
     if (heapCookieObject) {
       heapCookieObject = JSON.parse(decodeURIComponent(heapCookieObject));
     } else {
-      console.log("No heap cookie found.");
+      console.info("No heap cookie found.");
     }
 
     htmlSelector.buttonAddToCart =
@@ -113,11 +127,11 @@ var rudderTracking = (function () {
     fetchCart()
       .then((cart) => {
         const needToUpdateCart = checkCartNeedsToBeUpdated(cart);
-        if (needToUpdateCart) {
+        if (anonymousIdChanged || needToUpdateCart) {
           updateCartAttribute().then((cart) => {
             sendIdentifierToRudderWebhook(cart);
           });
-          console.log("Successfully updated cart");
+          console.debug("Successfully updated cart");
         }
         else {
           /* Used else condition as it was otherwise sending rudderIdentifier twice 
@@ -128,7 +142,7 @@ var rudderTracking = (function () {
         }
       })
       .catch((error) => {
-        console.log("Error occurred while updating cart:", error);
+        console.error("Error occurred while updating cart:", error);
       });
     productListViews();
 
@@ -376,10 +390,10 @@ var rudderTracking = (function () {
       })
       .then(() => {
         updateTimeStampForIdentifierEvent();
-        console.log("Successfully sent identifier event to rudderstack");
+        console.debug("Successfully sent identifier event to rudderstack");
       })
       .catch(() => {
-        console.log("Failed to sent identifier event to rudderstack");
+        console.error("Failed to sent identifier event to rudderstack");
       });
   }
   function updateTimeStampForIdentifierEvent() {
@@ -437,7 +451,7 @@ var rudderTracking = (function () {
         break;
 
       default:
-        console.log("RudderStack does not track this page");
+        console.info("RudderStack does not track this page");
     }
   }
 
@@ -487,7 +501,7 @@ var rudderTracking = (function () {
   function trackProductPages(mappedPageName) {
     const pagePath = window.location.pathname;
     if (pagePath === "/collections" || pagePath === "/products") {
-      console.log("RudderStack does not track this page");
+      console.info("RudderStack does not track this page");
     } else {
       const pagePathArr = pagePath.split("/");
       // If the url is = /products or /collections/{collectionId}
@@ -651,7 +665,7 @@ var rudderTracking = (function () {
     const url = getUrl();
     _getJsonData(url)
       .done(function (data) {
-        console.log(data);
+        console.debug(data);
         const { items } = data;
         const { currency } = data;
         const payload = {
@@ -681,7 +695,7 @@ var rudderTracking = (function () {
         rudderanalytics.track(event, payload);
       })
       .fail(function (error) {
-        console.log(error);
+        console.error(error);
       });
   }
 
@@ -704,7 +718,7 @@ var rudderTracking = (function () {
         rudderanalytics.track("Product Clicked", payload);
       })
       .fail(function (error) {
-        console.log(error);
+        console.error(error);
       });
   }
   function getCurrentVariantId() {
@@ -747,7 +761,7 @@ var rudderTracking = (function () {
         rudderanalytics.track(event, payload);
       })
       .fail(function (error) {
-        console.log(error);
+        console.error(error);
       });
   }
 
@@ -847,6 +861,6 @@ var rudderTracking = (function () {
   // init();
   script.addEventListener("load", function () {
     rs$ = $.noConflict(true);
-  init();
+    init();
   });
 })();

--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -85,7 +85,7 @@ var rudderTracking = (function () {
             }
           },
           error: function (xhr, status, error) {
-            console.error("Couldn't fetch Source Config due error: " + xhr.responseJSON.message);
+            console.debug("Couldn't fetch Source Config due error: " + xhr.responseJSON.message);
             resolve(true);
           }
         })
@@ -119,7 +119,7 @@ var rudderTracking = (function () {
     if (heapCookieObject) {
       heapCookieObject = JSON.parse(decodeURIComponent(heapCookieObject));
     } else {
-      console.info("No heap cookie found.");
+      console.debug("No heap cookie found.");
     }
 
     htmlSelector.buttonAddToCart =
@@ -142,7 +142,7 @@ var rudderTracking = (function () {
         }
       })
       .catch((error) => {
-        console.error("Error occurred while updating cart:", error);
+        console.debug("Error occurred while updating cart:", error);
       });
     productListViews();
 
@@ -393,7 +393,7 @@ var rudderTracking = (function () {
         console.debug("Successfully sent identifier event to rudderstack");
       })
       .catch(() => {
-        console.error("Failed to sent identifier event to rudderstack");
+        console.debug("Failed to sent identifier event to rudderstack");
       });
   }
   function updateTimeStampForIdentifierEvent() {
@@ -695,7 +695,7 @@ var rudderTracking = (function () {
         rudderanalytics.track(event, payload);
       })
       .fail(function (error) {
-        console.error(error);
+        console.log(error);
       });
   }
 
@@ -718,7 +718,7 @@ var rudderTracking = (function () {
         rudderanalytics.track("Product Clicked", payload);
       })
       .fail(function (error) {
-        console.error(error);
+        console.debug(error);
       });
   }
   function getCurrentVariantId() {
@@ -761,7 +761,7 @@ var rudderTracking = (function () {
         rudderanalytics.track(event, payload);
       })
       .fail(function (error) {
-        console.error(error);
+        console.debug(error);
       });
   }
 
@@ -861,6 +861,6 @@ var rudderTracking = (function () {
   // init();
   script.addEventListener("load", function () {
     rs$ = $.noConflict(true);
-    init();
+  init();
   });
 })();


### PR DESCRIPTION
## Description of the change

Reseting `rudderAnalytics` if a user logs out after logging in as it is a new user journey 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
