### PR TITLE
fix: double product clicked events

### DIFF
--- a/deviceModeInit.js
+++ b/deviceModeInit.js
@@ -153,7 +153,6 @@ var rudderTracking = (function () {
         console.debug("Error occurred while updating cart:", error);
       });
     productListViews();
-    productListPage();
     isClientSideIdentifierEventsEnabled().then(response => {
       if (!!response) {
         enableClientIdentifierEvents = true;


### PR DESCRIPTION
## Description of the change

> In #36 we added `productiLstView()` to be called on every page and also from `trackProductListPage()`. And  `trackProductListPage()` is also called on every page resulting in double event listener on every product and hence double `Product clicked` Event getting Triggered

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
