### PR TITLE
fix: remove redundant json header from get call to sourceConfig

### DIFF
--- a/src/deviceModeInit.js
+++ b/src/deviceModeInit.js
@@ -85,7 +85,7 @@ let _rudderTracking = (function () {
           }
         },
         error: function (xhr, _status, _error) {
-          console.debug("Couldn't fetch Source Config due error: " + xhr.responseJSON.message);
+          console.warn("Couldn't fetch Source Config due error: " + xhr.responseJSON.message);
           resolve(true);
         },
       });

--- a/src/deviceModeInit.js
+++ b/src/deviceModeInit.js
@@ -85,7 +85,11 @@ let _rudderTracking = (function () {
           }
         },
         error: function (xhr, _status, _error) {
-          console.warn("Couldn't fetch Source Config due error: " + xhr.responseJSON.message);
+          console.warn(
+            "Couldn't fetch Source Config due to error: " +
+              xhr.responseJSON.message +
+              ' Client-side event tracking will be enabled.',
+          );
           resolve(true);
         },
       });

--- a/src/deviceModeInit.js
+++ b/src/deviceModeInit.js
@@ -67,10 +67,10 @@ let _rudderTracking = (function () {
    */
   function isClientSideIdentifierEventsEnabled() {
     const authKey = btoa('writeKey_placeHolder' + ':');
-    const webhookUrl = 'configUrl_placeholder/sourceConfig';
+    const sourceConfigUrl = 'configUrl_placeholder/sourceConfig';
     return new Promise(function (resolve, _reject) {
       rs$.ajax({
-        url: webhookUrl,
+        url: sourceConfigUrl,
         method: 'GET',
         timeout: 2000, // 2 seconds timeout
         beforeSend: function (xhr) {

--- a/src/deviceModeInit.js
+++ b/src/deviceModeInit.js
@@ -72,7 +72,6 @@ let _rudderTracking = (function () {
       rs$.ajax({
         url: webhookUrl,
         method: 'GET',
-        contentType: 'application/json',
         timeout: 2000, // 2 seconds timeout
         beforeSend: function (xhr) {
           // Set the Authorization header


### PR DESCRIPTION
## What are the changes introduced in this PR?

Remove redundant `contentType: 'application/json'` header from get call to sourceConfig

## What is the related Linear task?

Resolves INT-3347

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
