### PR TITLE
chore: bump build-scan-push-action from v2.1.0 to v2.2.0

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -60,7 +60,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # 2.0.1
 
       - name: Build and Push Multi-platform Images to ECR
-        uses: rudderlabs/build-scan-push-action@96d7bfca912dd2e8805dbb322dc2540504ecac1e # v2.1.0
+        uses: rudderlabs/build-scan-push-action@865b4253caa57f8f20cd109e0efc1affe3a64939 # v2.2.0
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
## Summary
- Update `rudderlabs/build-scan-push-action` from `v2.1.0` to `v2.2.0`
- SHA: `96d7bfca912dd2e8805dbb322dc2540504ecac1e` → `865b4253caa57f8f20cd109e0efc1affe3a64939`

## Files changed
- `.github/workflows/build-and-push-docker-image.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)